### PR TITLE
Removed unnecessary and Windows-incompatible modification of process.env

### DIFF
--- a/src/execution/CommandRunner.ts
+++ b/src/execution/CommandRunner.ts
@@ -23,7 +23,7 @@ export default class CommandRunner implements ICommandRunner {
           const executionOptions = {
             cwd: project,
             timeout: EXEC_TIMEOUT,
-            env: _.merge(process.env, { PATH: process.env.PATH + ":/usr/local/bin" })
+            env: process.env
           };
           exec(command, executionOptions, (err, stdout, stderr) => {
               if (err) {


### PR DESCRIPTION
This hard-coded string assumes Unix and breaks Windows (it effectively renders the last path in PATH nonsense by appending a colin to it). Furthermore, _.merge modifies process.env in place, possibly breaking other things as well. There should be no reason that /usr/local/bin isn't already in the environment path on a Unix OS. I don't see any reason to append this or modify process.env at all.
